### PR TITLE
fix: Disable sparse checkout for deploy

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -125,12 +125,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          submodules: false
-          sparse-checkout: |
-            Makefile
-            template.yml
-            samconfig.toml
-          sparse-checkout-cone-mode: false
+          submodules: true
 
       - name: Install SAM CLI
         uses: aws-actions/setup-sam@v2


### PR DESCRIPTION
Apparently sam deploy needs access to the code that is referenced
via CodeUri in the templates.
